### PR TITLE
Enable version inference using the Reckon plug-in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "daily"
       time: "02:00"
     open-pull-requests-limit: 10
+    ignore:
+      # Ignore https://github.com/ajoberstar/reckon updates
+      # (version 0.13.2 is the last one compatible with Java 8).
+      - dependency-name: "org.ajoberstar.reckon:*"
+      - dependency-name: "org.ajoberstar.reckon.settings:*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           gradle-version: wrapper
           arguments: |
+            -Preckon.stage=snapshot
             publishAllPublicationsToGitHubRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -113,6 +114,7 @@ jobs:
         with:
           gradle-version: wrapper
           arguments: |
+            -Preckon.stage=snapshot
             publishToSonatype
             closeAndReleaseSonatypeStagingRepository
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           gradle-version: wrapper
           arguments: |
+            -Preckon.stage=final
             publishAllPublicationsToGitHubRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +50,7 @@ jobs:
         with:
           gradle-version: wrapper
           arguments: |
+            -Preckon.stage=final
             publishToSonatype
             closeAndReleaseSonatypeStagingRepository
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
+    id("com.saveourtool.kompiledb.versioning-configuration")
     id("com.saveourtool.kompiledb.publishing-configuration")
 }
 
 group = "com.saveourtool.kompiledb"
-version = "1.0.1-SNAPSHOT"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,8 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.gradle.kotlin.dsl.plugins)
     implementation(libs.dokka.gradle.plugin)
-    implementation(libs.gradle.nexus.publish.plugin)
+    implementation(libs.nexus.publish.gradle.plugin)
+    implementation(libs.reckon.gradle.plugin)
 
     /*
      * Workaround for https://github.com/gradle/gradle/issues/15383:

--- a/buildSrc/src/main/kotlin/com/saveourtool/kompiledb/versioning-configuration.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/saveourtool/kompiledb/versioning-configuration.gradle.kts
@@ -1,0 +1,14 @@
+package com.saveourtool.kompiledb
+
+plugins {
+    id("org.ajoberstar.reckon")
+}
+
+reckon {
+    /*
+     * See https://github.com/ajoberstar/reckon/blob/0.13.2/docs/index.md
+     * for more details.
+     */
+    scopeFromProp()
+    snapshotFromProp()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,10 @@ kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1g
 org.gradle.java.installations.auto-download=false
+
+# minor: 1.0.0 -> 1.1.0-SNAPSHOT
+# patch: 1.0.0 -> 1.0.1-SNAPSHOT
+reckon.scope=patch
+
+# Either `snapshot` or `final`.
+reckon.stage=snapshot

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,9 @@ gson = "2.10.1"
 kotlin = "1.9.0"
 kotest = "5.6.2"
 dokka = "1.8.20"
-gradle-nexus-publish-plugin = "1.3.0"
+nexus-publish-gradle-plugin = "1.3.0"
+# The last version compatible with Java 8 is 0.13.2.
+reckon-gradle-plugin = "0.13.2"
 
 [plugins]
 
@@ -16,4 +18,5 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-gradle-nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "gradle-nexus-publish-plugin"}
+nexus-publish-gradle-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-gradle-plugin"}
+reckon-gradle-plugin = { module = "org.ajoberstar.reckon:org.ajoberstar.reckon.gradle.plugin", version.ref = "reckon-gradle-plugin" }


### PR DESCRIPTION
Version 0.13.2 is the last one compatible with Java 8.