### PR TITLE
Remove the version check introduced with #44

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,15 +89,9 @@ jobs:
             **/build/test-results/*/TEST-*.xml
           retention-days: 1
 
-      - name: 'Determine whether the current version is a SNAPSHOT one'
-        id: version
-        run: |
-          echo "version=$(./gradlew --no-daemon --console=plain -q :properties 2>/dev/null | grep '^version:' | awk '{ print $2 }')" >>${GITHUB_OUTPUT}
-        shell: bash
-
       - name: 'Publish a snapshot to GitHub (Java 8 only)'
         id: publish-github
-        if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref == 'refs/heads/master' && matrix.java-version == 8 && endsWith(steps.version.outputs.version, '-SNAPSHOT') }}
+        if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref == 'refs/heads/master' && matrix.java-version == 8 }}
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
@@ -109,7 +103,7 @@ jobs:
 
       - name: 'Publish a snapshot to Maven Central (Java 8 only)'
         id: publish-sonatype
-        if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref == 'refs/heads/master' && matrix.java-version == 8 && endsWith(steps.version.outputs.version, '-SNAPSHOT') }}
+        if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.ref == 'refs/heads/master' && matrix.java-version == 8 }}
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper


### PR DESCRIPTION
It's useless when using version inference via Reckon Gradle plug-in.